### PR TITLE
Добавление настроек, фикс для селекта пункта выдачи заказов

### DIFF
--- a/assets/css/edostavka.css
+++ b/assets/css/edostavka.css
@@ -1,0 +1,3 @@
+.input-hidden {
+    display: none !important;
+}

--- a/assets/js/edostavka.js
+++ b/assets/js/edostavka.js
@@ -22,10 +22,21 @@ jQuery(function($){
                     if( $.inArray( parseInt( tatiff_id ), woocommerce_params.is_door ) >= 0 ) {
                         //Если СДЕК до двери
                         $( '#billing_delivery_point_field' ).hide().addClass('hidden');
+                        //Для корректной работы с Select2
+                        $( '#billing_delivery_point').hide().addClass('hidden');
+                        $( '#s2id_billing_delivery_point').hide().addClass('hidden');
                         $( '#billing_address_1_field, #billing_address_2_field').show().removeClass('hidden');
                     } else {
                         //Если СДЕК до склада
                         $( '#billing_delivery_point_field' ).show().removeClass('hidden');
+                        //Для корректной работы с Select2
+                        if (document.getElementById("s2id_billing_delivery_point") !== null) {
+                            $('#s2id_billing_delivery_point').show().removeClass('hidden');
+                            $( '#billing_delivery_point').hide().addClass('hidden');
+                        } else {
+                            $('#billing_delivery_point').show().removeClass('hidden');
+                        }
+
                         $( '#billing_address_1_field, #billing_address_2_field' ).hide().addClass('hidden');
                     }
 

--- a/includes/class-wc-edostavka-connect.php
+++ b/includes/class-wc-edostavka-connect.php
@@ -203,7 +203,6 @@ class WC_Edostavka_Connect {
 				if ( 'yes' == $this->debug ) {
 					$this->log->add( $this->id, 'Ответ от сервера СДЕК [' . self::get_service_name( $service ) . ']: ' . print_r( $result, true ) );
 				}
-				
 				$values[ $service ] = $result;
 				
 			} else {

--- a/includes/class-wc-edostavka-shipping.php
+++ b/includes/class-wc-edostavka-shipping.php
@@ -50,10 +50,6 @@ class WC_Edostavka_Shipping_Method extends WC_Shipping_Method {
 
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
 
-		if ($this->hide_standart_wc_city === 'yes') {
-			add_filter( 'woocommerce_checkout_fields' , array($this, 'hide_city_checkout_fields'));
-		}
-
 		if ( 'yes' == $this->debug ) {
 			$this->log = WC_Edostavka::logger();
 		}
@@ -428,11 +424,5 @@ class WC_Edostavka_Shipping_Method extends WC_Shipping_Method {
 					wc_add_notice( $this->error_text, 'error');
 			}			
 		}
-	}
-
-	function hide_city_checkout_fields( $fields ) {
-		$fields['billing']['billing_city']['class'][] = 'input-hidden';
-		$fields['shipping']['shipping_city']['class'][] = 'input-hidden';
-		return $fields;
 	}
 }

--- a/wc-edostavka.php
+++ b/wc-edostavka.php
@@ -42,6 +42,14 @@ class WC_Edostavka {
 
 		add_filter( 'woocommerce_checkout_fields' , array($this, 'override_checkout_billing_state'));
 
+		// hide city field
+		$settings = get_option( 'woocommerce_' . 'edostavka' . '_settings', null );
+		if (array_key_exists('hide_standart_wc_city', $settings)
+			&& $settings['hide_standart_wc_city'] === 'yes'
+		) {
+			add_filter('woocommerce_checkout_fields', array($this, 'edostavka_hide_city_checkout_fields'));
+		}
+
 		//Ajax
 		add_filter( 'woocommerce_update_order_review_fragments',  array( $this, 'ajax_update_delivery_points' ) );
 
@@ -221,6 +229,12 @@ class WC_Edostavka {
 		return $fields;
 	}
 
+	public function edostavka_hide_city_checkout_fields( $fields ) {
+		$fields['billing']['billing_city']['class'][] = 'input-hidden';
+		$fields['shipping']['shipping_city']['class'][] = 'input-hidden';
+		return $fields;
+	}
+
 	public function add_ons_attributes( $checkout_fields ){
 
 		$checkout_fields['billing']['billing_delivery_point'] = array(
@@ -353,5 +367,6 @@ function edostavka_load_states( $states ) {
 
 	return $states;
 }
+
 
 

--- a/wc-edostavka.php
+++ b/wc-edostavka.php
@@ -30,6 +30,8 @@ class WC_Edostavka {
 		$this->includes();
 		if ( is_admin() ) {
 			$this->admin_includes();
+		} else {
+			wp_enqueue_style( 'wc-edostavka', WP_PLUGIN_URL . '/wc-edostavka/assets/css/edostavka.css', array());
 		}
 		add_filter( 'woocommerce_shipping_methods', array( $this, 'add_method' ) );
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'add_ons_attributes') );
@@ -37,7 +39,9 @@ class WC_Edostavka {
 		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'checkout_field_update_order_meta' ) );
 		add_action( 'woocommerce_email_order_meta', array( $this, 'email_order_meta' ), 99 );
 		add_filter( 'default_checkout_state', array( &$this, 'default_checkout_state' ), 99 );
-		
+
+		add_filter( 'woocommerce_checkout_fields' , array($this, 'override_checkout_billing_state'));
+
 		//Ajax
 		add_filter( 'woocommerce_update_order_review_fragments',  array( $this, 'ajax_update_delivery_points' ) );
 
@@ -61,7 +65,7 @@ class WC_Edostavka {
 				array( 'jquery' )
 			);
 	}
-	
+
 	public static function get_instance() {
 		if ( null == self::$instance ) {
 			self::$instance = new self;
@@ -201,6 +205,20 @@ class WC_Edostavka {
 		}
 
 		return $przlist;
+	}
+
+	function override_checkout_billing_state( $fields ) {
+		if (isset($fields['billing']['billing_state'])) {
+			$fields['billing']['billing_state']['label'] = __( 'City', 'woocommerce' );
+			$fields['billing']['billing_state']['required'] = true;
+		} else {
+			$fields['billing']['billing_state'] = array(
+				'type' => 'state',
+				'label' => __( 'Town / City', 'woocommerce' ),
+				'required'  => true
+			);
+		}
+		return $fields;
 	}
 
 	public function add_ons_attributes( $checkout_fields ){


### PR DESCRIPTION
Добавлены:
1) Настройки для переопределения названий доставки отдельно до двери и до склада
2) Возможность скрыть стандартное поле "Город" (т.к. используется поле state). Это можно делать и через хук, но настройка удобнее.
3) Настройка для автовыбора доставки через СДЭК
4) Совместимость поля billing_delivery_point с Select2 (если применить Select2 для этого поля, то JS код для скрытия/показа в зависимости от типа доставки показывает стандартное поле select и на форме показываются оба)
